### PR TITLE
add missing "coming soon" repositories to the index

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,12 +59,24 @@
             the compiler for the <code>Oberon</code> programming language.
             <br>
             <img src="res/oberon.png" height=20></img>
+            <a class="external" href="https://github.com/oberonproject/library" target="_blank">library</a>:
+            modern libraries for the Oberon programming language.
+            <br>
+            <img src="res/oberon.png" height=20></img>
+            <a class="external" href="https://github.com/oberonproject/oakwood_library" target="_blank">oakwood_library</a>:
+            the libraries for the language as defined in the Oakwood Guidelines for the Oberon 2 version.
+            <br>
+            <img src="res/oberon.png" height=20></img>
             <a class="external" href="https://github.com/oberonproject/formatter" target="_blank">formatter</a>:
             A tool to automatically format Oberon source text.
             <br>
             <img src="res/oberon.png" height=20></img>
             <a class="external" href="https://github.com/oberonproject/linter" target="_blank">linter</a>:
             A tool to analyze Oberon source text and catch bugs and stylistic errors.
+            <br>
+            <img src="res/oberon.png" height=20></img>
+            <a class="external" href="https://github.com/oberonproject/tree-sitter-oberon" target="_blank">tree-sitter-oberon</a>:
+            grammar support for IDEs
         </p>
     </body>
 </html>


### PR DESCRIPTION
This PR adds some missing repositories to the index:
- [library](https://github.com/oberonproject/library)
- [oakwood_library](https://github.com/oberonproject/oakwood_library)
- [formatter](https://github.com/oberonproject/formatter)
- [linter](https://github.com/oberonproject/linter)
- [tree-sitter-oberon](https://github.com/oberonproject/tree-sitter-oberon)
