### PR TITLE
FIX: use the new name of the organization

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,14 @@
 <html>
     <head>
-        <title>Oberon Project</title>
+        <title>Oberon For All</title>
         <link rel="stylesheet" href="style.css">
     </head>
     <body>
-        <h1 align="center">The ISAE <code>Oberon</code> Project</h1>
+        <h1 align="center"><code>Oberon</code> For All</h1>
 
         <p>
-            Welcome to the <code>Oberon</code> Projet of ISAE-Supaero.
+            Welcome to <code>Oberon</code> For All: an ISAE-Supaero initiative
+            <img src="https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif" width="50"></img>
         </p>
 
         <hr>
@@ -18,7 +19,7 @@
 
         <p>
             The whole project is hosted as 
-            <a class="external" href="https://github.com/oberonproject" target="_blank">oberonproject</a>
+            <a class="external" href="https://github.com/oberonforall" target="_blank">oberonforall</a>
             on <i>GitHub</i>
         </p>
 
@@ -32,50 +33,50 @@
             Below is the list of all publicly available tools and smaller projects:
             <br>
             <img src="res/oberon.png" height=20></img>
-            <a class="external" href="https://github.com/oberonproject/oberonproject.github.io" target="_blank">oberonproject.github.io</a>:
+            <a class="external" href="https://github.com/oberonforall/oberonforall.github.io" target="_blank">oberonforall.github.io</a>:
             this website
             <br>
             <img src="res/oberon.png" height=20></img>
-            <a class="external" href="https://github.com/oberonproject/obnc" target="_blank">obnc</a>:
+            <a class="external" href="https://github.com/oberonforall/obnc" target="_blank">obnc</a>:
             a tool to compile <code>Oberon</code> using translation to <code>c</code> and <code>gcc</code>.
             <br>
             <img src="res/oberon.png" height=20></img>
-            <a class="external" href="https://github.com/oberonproject/obnc-libext" target="_blank">obnc-libext</a>:
+            <a class="external" href="https://github.com/oberonforall/obnc-libext" target="_blank">obnc-libext</a>:
             external libraries for <code>obnc</code>.
             <br>
             <img src="res/oberon.png" height=20></img>
-            <a class="external" href="https://github.com/oberonproject/obnc-libstd" target="_blank">obnc-libstd</a>:
+            <a class="external" href="https://github.com/oberonforall/obnc-libstd" target="_blank">obnc-libstd</a>:
             standard libraries for <code>obnc</code>.
             <br>
             <img src="res/oberon.png" height=20></img>
-            <a class="external" href="https://github.com/oberonproject/syntax" target="_blank">syntax</a>:
+            <a class="external" href="https://github.com/oberonforall/syntax" target="_blank">syntax</a>:
             some work on the syntax of the language, e.g. structuring it, enhancing it.
         </p>
         <p>
             And projects available soon:
             <br>
             <img src="res/oberon.png" height=20></img>
-            <a class="external" href="https://github.com/oberonproject/compiler" target="_blank">compiler</a>:
+            <a class="external" href="https://github.com/oberonforall/compiler" target="_blank">compiler</a>:
             the compiler for the <code>Oberon</code> programming language.
             <br>
             <img src="res/oberon.png" height=20></img>
-            <a class="external" href="https://github.com/oberonproject/library" target="_blank">library</a>:
+            <a class="external" href="https://github.com/oberonforall/library" target="_blank">library</a>:
             modern libraries for the Oberon programming language.
             <br>
             <img src="res/oberon.png" height=20></img>
-            <a class="external" href="https://github.com/oberonproject/oakwood_library" target="_blank">oakwood_library</a>:
+            <a class="external" href="https://github.com/oberonforall/oakwood_library" target="_blank">oakwood_library</a>:
             the libraries for the language as defined in the Oakwood Guidelines for the Oberon 2 version.
             <br>
             <img src="res/oberon.png" height=20></img>
-            <a class="external" href="https://github.com/oberonproject/formatter" target="_blank">formatter</a>:
+            <a class="external" href="https://github.com/oberonforall/formatter" target="_blank">formatter</a>:
             A tool to automatically format Oberon source text.
             <br>
             <img src="res/oberon.png" height=20></img>
-            <a class="external" href="https://github.com/oberonproject/linter" target="_blank">linter</a>:
+            <a class="external" href="https://github.com/oberonforall/linter" target="_blank">linter</a>:
             A tool to analyze Oberon source text and catch bugs and stylistic errors.
             <br>
             <img src="res/oberon.png" height=20></img>
-            <a class="external" href="https://github.com/oberonproject/tree-sitter-oberon" target="_blank">tree-sitter-oberon</a>:
+            <a class="external" href="https://github.com/oberonforall/tree-sitter-oberon" target="_blank">tree-sitter-oberon</a>:
             grammar support for IDEs
         </p>
     </body>


### PR DESCRIPTION
As stated in https://github.com/orgs/oberonforall/discussions/85, the name of the organization has changed from "Oberon Project" to "Oberon For All" which is different from "Project Oberon" and more inclusive for newcomers :+1: 

This PR:
- fixes the URLs by replacing `oberonproject` with the new `oberonforall`
- changes the titles accordingly
- adds a little `:wave:` GIF to have some nice welcoming animation :relieved: 
 
### the animation: <img src="https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif" width="20"></img>
